### PR TITLE
Fixed some default settings present in picom.sample.conf

### DIFF
--- a/picom.sample.conf
+++ b/picom.sample.conf
@@ -167,9 +167,11 @@ frame-opacity = 0.7;
 
 # Default opacity for dropdown menus and popup menus. (0.0 - 1.0, defaults to 1.0)
 # menu-opacity = 1.0 
-# menu-opacity is depreciated use dropdown-menu and popup-menu instead
-#popup_menu = { opacity = 0.x; }
-#dropdown_menu = { opacity = 0.x; }
+# menu-opacity is depreciated use dropdown-menu and popup-menu instead.
+
+#If using these 2 below change their values in line 510 & 511 aswell
+popup_menu = { opacity = 0.8; }
+dropdown_menu = { opacity = 0.8; }
 
 
 # Let inactive opacity set by -i override the '_NET_WM_OPACITY' values of windows.

--- a/picom.sample.conf
+++ b/picom.sample.conf
@@ -15,7 +15,7 @@ size-transition = true
 #             Corners           #
 #################################
 # requires: https://github.com/sdhand/compton or https://github.com/jonaburg/picom
-corner-radius = 25.0;
+corner-radius = 10.0;
 rounded-corners-exclude = [
   #"window_type = 'normal'",
   "class_g = 'awesome'",
@@ -166,7 +166,11 @@ inactive-opacity = 0.8;
 frame-opacity = 0.7;
 
 # Default opacity for dropdown menus and popup menus. (0.0 - 1.0, defaults to 1.0)
-# menu-opacity = 1.0
+# menu-opacity = 1.0 
+# menu-opacity is depreciated use dropdown-menu and popup-menu instead
+#popup_menu = { opacity = 0.x; }
+#dropdown_menu = { opacity = 0.x; }
+
 
 # Let inactive opacity set by -i override the '_NET_WM_OPACITY' values of windows.
 # inactive-opacity-override = true
@@ -404,7 +408,9 @@ detect-client-leader = true
 # The opposing option is use-damage
 #
 # no-use-damage = false
-use-damage = true
+#use-damage = true (Causing Weird Black semi opaque rectangles when terminal is opened)
+#Changing use-damage to false fixes the problem
+use-damage = false
 
 # Use X Sync fence to sync clients' draw calls, to make sure all draw 
 # calls are finished before picom starts drawing. Needed on nvidia-drivers 


### PR DESCRIPTION
Important Changes
1. "**use-damage**"  value changed from true to false as it was causing issues written in the comment in line 413. Image for that is attached.
2. Also when running picom from terminal and using "**menu-opacity**" it shows that it is deprecated. Therefore a comment was added in line 170 to tell the users about it, and to make them use "**dropdown_menu**" & "**popup_menu**" present on line 173 & 174 instead.

![weird_black_boxes2](https://user-images.githubusercontent.com/72189840/94784395-b8597380-03eb-11eb-8f03-b456567e23f3.png)

![weird_black_boxes](https://user-images.githubusercontent.com/72189840/94784286-9233d380-03eb-11eb-9bdb-6a50e3673294.png)

Not so Important but life changing changes
1. "**corner-radius**"  on line 18 changed from 25.0 to 10.0, as 25.0 was too high and made things look ugly, also since it was too large some text on the corner of terminal became hidden.
